### PR TITLE
Repair build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #IDE configuration files
 .idea
 .vscode
+.history
 
 # Dependency directory
 node_modules

--- a/angular.json
+++ b/angular.json
@@ -203,5 +203,5 @@
       }
     }
   },
-  "defaultProject": "ngx-avatars-demo"
+  "defaultProject": "ngx-avatars"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "testing",
+  "name": "ngx-avatars",
   "version": "1.0.0",
   "homepage": "https://github.com/Heatmanofurioso/ngx-avatars",
   "description": "README.md",
@@ -17,7 +17,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --configuration production",
     "postbuild": "node scripts/copy-artifacts.js",
     "test": "ng test",
     "lint": "ng lint",

--- a/projects/ngx-avatars/tsconfig.lib.prod.json
+++ b/projects/ngx-avatars/tsconfig.lib.prod.json
@@ -1,6 +1,6 @@
 {
     "extends": "./tsconfig.lib.json",
     "angularCompilerOptions": {
-        "enableIvy": true
+        "compilationMode": "partial"
     }
 }

--- a/scripts/copy-artifacts.js
+++ b/scripts/copy-artifacts.js
@@ -4,7 +4,7 @@ const path = require("path");
 const artifacts = ["README.md", "LICENSE"];
 artifacts.forEach(artifact => {
   const fromPath = path.resolve(__dirname, "..", artifact);
-  const toPath = path.resolve(__dirname, "..", "dist\\ngx-avatars", artifact);
+  const toPath = path.resolve(__dirname, "..", "dist/ngx-avatars", artifact);
 
   fs.readFile(fromPath, "utf-8", (err, data) => {
     if (err) {


### PR DESCRIPTION
This PR aims to repair the build of this lib.

It closes #20

Tasks:
- handle new Ivy compiler
- repair post-script copy


Note: it is compatible with node 17 with an extra option:
```sh
NODE_OPTIONS="--openssl-legacy-provider" yarn build
```