### PR TITLE
Update Travis CI node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - '17.0.1'
 dist: trusty
 os: linux
+cache: yarn
 addons:
     chrome: stable
 before_script:
@@ -12,9 +13,8 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.17
   - export PATH=$HOME/.yarn/bin:$PATH
-  - npm install yarn
 deploy:
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '17.0.1'
+  - '16.8.0'
 dist: trusty
 os: linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '15.10.0'
+  - '17.0.1'
 dist: trusty
 os: linux
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 node_js:
   - '17.0.1'
-dist: trusty
-os: linux
-cache: yarn
 addons:
     chrome: stable
 before_script:
@@ -13,8 +10,13 @@ before_install:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.17
-  - export PATH=$HOME/.yarn/bin:$PATH
+  # Repo for Yarn
+  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
+  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+  - sudo apt-get update -qq
+  - sudo apt-get install -y -qq yarn
+cache:
+  yarn: true
 deploy:
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
   - '17.0.1'
+dist: trusty
+os: linux
 addons:
     chrome: stable
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - npm update -g yarn
+  - npm install yarn
 deploy:
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
+  - npm update -g yarn
 deploy:
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,7 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   # Repo for Yarn
-  - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
+  - npm i -g yarn
 cache:
   yarn: true
 deploy:


### PR DESCRIPTION
Travis CI has marked the Yarn version used in the project as deprecated, therefore we are upgrading Node to the latest stable version in order to bring in the updated bundled Yarn dependency