### PR TITLE
Fix missing imports for standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,21 @@ export class AppModule { }
 
 ```
 
+Here's an example on how to import the `AvatarComponent` directly into your `standalone` component.
+
+```typescript
+import { Component } from '@angular/core';
+import { AvatarComponent } from 'ngx-avatars';
+
+@Component({
+  selector: 'app',
+  template: '<ngx-avatars></ngx-avatars>',
+  imports: [AvatarComponent],
+  standalone: false // this is no longer needed in Angular 19+ since it defaults to `false`
+})
+export class AppComponent {}
+```
+
  **Avatar Styling**
 
  In addition to the style attribute, ngx-avatar style can be customized using css classes. Thus, the generated code offers two css classes that can be overridden :

--- a/projects/ngx-avatars/src/lib/avatar.component.ts
+++ b/projects/ngx-avatars/src/lib/avatar.component.ts
@@ -16,7 +16,7 @@ import {AvatarService} from './avatar.service';
 import {AvatarSource} from './sources/avatar-source.enum';
 import {takeWhile, map} from 'rxjs/operators';
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
-import {NgStyle} from "@angular/common";
+import {NgStyle, NgIf, NgTemplateOutlet} from "@angular/common";
 
 type Style = Partial<CSSStyleDeclaration>;
 
@@ -65,7 +65,9 @@ type Style = Partial<CSSStyleDeclaration>;
     </div>
   `,
   imports: [
-    NgStyle
+    NgStyle,
+    NgIf,
+    NgTemplateOutlet
   ],
   standalone: true
 })


### PR DESCRIPTION
Hello, there was the following bugs:
```
        cons:error ✘  NG0303: Can't bind to 'ngIf' since it isn't a known property of 'img' (used in the '_AvatarComponent' component template).
                      If the 'ngIf' is an Angular control flow directive, please make sure that either the 'NgIf' directive or the 'CommonModule' is included in the '@Component.imports' of this component.
        cons:error ✘  NG0303: Can't bind to 'ngIfElse' since it isn't a known property of 'img' (used in the '_AvatarComponent' component template).
                      1. If 'img' is an Angular component and it has the 'ngIfElse' input, then verify that it is included in the '@Component.imports' of this component.
                      2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@Component.schemas' of this component.
        cons:error ✘  NG0303: Can't bind to 'ngIf' since it isn't a known property of 'img' (used in the '_AvatarComponent' component template).
                      If the 'ngIf' is an Angular control flow directive, please make sure that either the 'NgIf' directive or the 'CommonModule' is included in the '@Component.imports' of this component.
        cons:error ✘  NG0303: Can't bind to 'ngIfElse' since it isn't a known property of 'img' (used in the '_AvatarComponent' component template).
                      1. If 'img' is an Angular component and it has the 'ngIfElse' input, then verify that it is included in the '@Component.imports' of this component.
                      2. To allow any property add 'NO_ERRORS_SCHEMA' to the '@Component.schemas' of this component.
```
This fix addresses those including the missing `NgOutletTemplate`.

Closes #68 

Please merge.

Thanks.